### PR TITLE
Add URL as Sitelinks field

### DIFF
--- a/models.go
+++ b/models.go
@@ -89,6 +89,7 @@ type SiteLink struct {
 	Site   string   `json:"site"`
 	Title  string   `json:"title"`
 	Badges []string `json:"badges"`
+	URL    string   `json:"url"`
 }
 
 // Claim represents wikidata claims data


### PR DESCRIPTION
As mentioned in https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities (wikidata wbgetentities API), if we pass `sitelinks/urls` as one of the props, the returned sitelinks will have URL field. Here's the example of the response
``` 
[
...
        "yiwiki": {
          "site": "yiwiki",
          "title": "\u05e0\u05d9\u05d5 \u05d9\u05d0\u05e8\u05e7 \u05d8\u05d9\u05d9\u05de\u05e1",
          "badges": [],
          "url": "https://yi.wikipedia.org/wiki/%D7%A0%D7%99%D7%95_%D7%99%D7%90%D7%A8%D7%A7_%D7%98%D7%99%D7%99%D7%9E%D7%A1"
        },
...
]
```

The said URL field is not available in Sitelink struct causing us can not access the value.

This PR basically add the said field so we can access the URL value.