### PR TITLE
Allow custom domains

### DIFF
--- a/gowikidata.go
+++ b/gowikidata.go
@@ -8,15 +8,21 @@ import (
 	"github.com/Navid2zp/easyreq"
 )
 
+var (
+	WikipediaDomain    = "https://en.wikipedia.org"
+	WikidataDomain     = "https://www.wikidata.org"
+	ImageResizerDomain = "https://commons.wikimedia.org"
+)
+
 const (
-	wikipediaQueryURL = "https://en.wikipedia.org/w/api.php?action=query&prop=pageprops&titles=%s&format=json"
-	wikiDataAPIURL    = "https://www.wikidata.org/w/api.php?action=%s&format=json"
-	imageResizerURL   = "https://commons.wikimedia.org/w/thumb.php?width=%d&f=%s"
+	wikipediaQueryURL = "%s/w/api.php?action=query&prop=pageprops&titles=%s&format=json"
+	wikiDataAPIURL    = "%s/w/api.php?action=%s&format=json"
+	imageResizerURL   = "%s/w/thumb.php?width=%d&f=%s"
 )
 
 // GetPageItem returns Wikipedia page item ID
 func GetPageItem(slug string) (string, error) {
-	url := fmt.Sprintf(wikipediaQueryURL, slug)
+	url := fmt.Sprintf(wikipediaQueryURL, WikipediaDomain, slug)
 
 	wikipediaQuery := WikiPediaQuery{}
 	res, err := easyreq.Make("get", url, nil, "", "json", &wikipediaQuery, nil)
@@ -47,7 +53,7 @@ func NewGetEntities(ids []string) (*WikiDataGetEntitiesRequest, error) {
 	}
 
 	req := WikiDataGetEntitiesRequest{
-		URL: fmt.Sprintf(wikiDataAPIURL, "wbgetentities"),
+		URL: fmt.Sprintf(wikiDataAPIURL, WikidataDomain, "wbgetentities"),
 	}
 	req.setParam("ids", &ids)
 	return &req, nil
@@ -135,7 +141,7 @@ func NewGetClaims(entity, claim string) (*WikiDataGetClaimsRequest, error) {
 	}
 
 	req := WikiDataGetClaimsRequest{
-		URL: fmt.Sprintf(wikiDataAPIURL, "wbgetclaims"),
+		URL: fmt.Sprintf(wikiDataAPIURL, WikidataDomain, "wbgetclaims"),
 	}
 	if entity != "" {
 		req.setParam("entity", &[]string{entity})
@@ -187,8 +193,8 @@ func (r *WikiDataGetClaimsRequest) Get() (*map[string][]Claim, error) {
 // WikiData action: wbavailablebadges
 // WikiData API page: https://www.wikidata.org/w/api.php?action=help&modules=wbavailablebadges
 func GetAvailableBadges() ([]string, error) {
-	var data struct{Badges []string}
-	url := fmt.Sprintf(wikiDataAPIURL, "wbavailablebadges")
+	var data struct{ Badges []string }
+	url := fmt.Sprintf(wikiDataAPIURL, WikidataDomain, "wbavailablebadges")
 	res, err := easyreq.Make("GET", url, nil, "", "json", &data, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +212,7 @@ func GetAvailableBadges() ([]string, error) {
 // WikiData API page: https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentities
 func NewSearch(search, language string) (*WikiDataSearchEntitiesRequest, error) {
 	req := WikiDataSearchEntitiesRequest{
-		URL:      fmt.Sprintf(wikiDataAPIURL, "wbsearchentities"),
+		URL:      fmt.Sprintf(wikiDataAPIURL, WikidataDomain, "wbsearchentities"),
 		Language: language,
 		// default api value
 		Limit: 7,
@@ -296,7 +302,7 @@ func (r *SearchEntitiesResponse) Next() (*SearchEntitiesResponse, error) {
 
 // ImageResizer returns the url for resizing a wikimedia image to the given size
 func ImageResizer(imageName string, size int) string {
-	return fmt.Sprintf(imageResizerURL, size, imageName)
+	return fmt.Sprintf(imageResizerURL, ImageResizerDomain, size, imageName)
 }
 
 func createParam(param string, values []string) string {


### PR DESCRIPTION
Right now it is impossible to use a mock server such as the provided by the [HTTPTest package](https://pkg.go.dev/net/http/httptest), as the Wikimedia domains are hardcoded.

This PR extract these domains to public variables. These variables can be overwritten by tests to allow for mocked responses and avoid hitting the real Wikimedia servers when testing, and keep the real domain values by default.