### PR TITLE
Add user agent to requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Navid2zp/go-wikidata
 
 go 1.16
-
-require github.com/Navid2zp/easyreq v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/Navid2zp/easyreq v1.1.0 h1:l72URNUdG7u2bsEwc+I/XvlIqHyK1wQh45zlJVfglOs=
-github.com/Navid2zp/easyreq v1.1.0/go.mod h1:mXy1+Mp8NBc3ujieKS27RS84REq138ZCvtpj8hFUeYk=


### PR DESCRIPTION
Wikidata requests are being rejected with a 403 due to missing user agent header. This is causing errors like `invalid character 'P' looking for beginning of value`. Wikidata API was returning a 403 Forbidden response with the message "Please set a user-agent and respect our robot policy" instead of the expected JSON response. The response started with the character 'P' from "Please", which caused the JSON parsing to fail.

See https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy

